### PR TITLE
- Fixed: podspec including unnecessary files in the iOS bundle 

### DIFF
--- a/Colloc.podspec
+++ b/Colloc.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'Colloc'
-    s.version          = '1.0.3'
+    s.version          = '1.0.4'
     s.summary          = 'Collaborative Localizations for iOS and Android using Google Documents'
     
     s.description      = <<-DESC
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/mobilejazz/Colloc.git', :tag => s.version.to_s }
     s.social_media_url = 'https://twitter.com/mobilejazzcom'
     
-    s.resources = ['colloc.php', 'run_script_sample.sh']
+    s.preserve_paths = ['colloc.php', 'run_script_sample.sh']
 end


### PR DESCRIPTION
#### What does this PR do?
Avoids the inclusion of Colloc.php & run_script_sample.sh to the Xcode as resources.

##### Why are we doing this? Any context or related work?
In the current implementation those files are included in the project as resources and later copied to the binary file.

*Content of the example JaX.app*
<img width="403" alt="screen shot 2018-11-02 at 19 03 57" src="https://user-images.githubusercontent.com/1536171/47936861-516d7000-dedf-11e8-97e9-cfd6e7d90b77.png">

In some projects – specially when using extensions – the AppStore will detect the files as unsigned source code files and will produce a validation error. 

![884103472144545 c0wkeigr41vv5ubcynne_height640](https://user-images.githubusercontent.com/1536171/47937050-e07a8800-dedf-11e8-8dac-1e946224799a.png)

##### Proposed solution
Files will be copied when using the new Podspec file but not added to the Xcode project 